### PR TITLE
Use timezone-aware UTC in crown_seed

### DIFF
--- a/src/crown_seed.py
+++ b/src/crown_seed.py
@@ -26,7 +26,7 @@ def main():
         prompt = input("⥁  ")          # PAL hook placeholder
     except (KeyboardInterrupt, EOFError):
         prompt = ""
-    stamp = datetime.datetime.utcnow().isoformat(timespec="seconds")
+    stamp = datetime.datetime.now(datetime.UTC).isoformat(timespec="seconds")
     print(f"⥁⟨{prompt.strip()}⟩⥁  # {stamp}")   # crown echo
 
     stop_flag["halt"] = True           # stop tickers and exit


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.datetime.utcnow()` with `datetime.datetime.now(datetime.UTC)` in `crown_seed`

## Testing
- `python src/crown_seed.py <<'EOF'

EOF`

------
https://chatgpt.com/codex/tasks/task_e_688e45b2c8e4832da0a8765d58be486b